### PR TITLE
Add whitelist

### DIFF
--- a/contracts/SuperpowerNFT.sol
+++ b/contracts/SuperpowerNFT.sol
@@ -67,10 +67,9 @@ contract SuperpowerNFT is ISuperpowerNFT, SuperpowerNFTBase {
   }
 
   function mint(address to, uint256 amount) public override onlyMinter canMint(amount) {
-    uint id = _wl.getIdByBurner(address(this));
     if (block.timestamp < _whitelistActiveUntil) {
       // verify if whitelisted
-      require(_wl.balanceOf(to, id) >= amount, "SuperpowerNFT: not enough slot in whitelist");
+      require(_wl.balanceOf(to, _wl.getIdByBurner(address(this))) >= amount, "SuperpowerNFT: not enough slot in whitelist");
     }
     require(_nextTokenId + amount - 1 < _maxSupply + 1, "SuperpowerNFT: token id our of range");
     for (uint256 i = 0; i < amount; i++) {
@@ -78,7 +77,7 @@ contract SuperpowerNFT is ISuperpowerNFT, SuperpowerNFTBase {
     }
     if (block.timestamp < _whitelistActiveUntil) {
       // burn whitelisted token
-      _wl.burn(to, id, amount);
+      _wl.burn(to, _wl.getIdByBurner(address(this)), amount);
     }
   }
 

--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -87,11 +87,11 @@ contract SuperpowerNFTBase is
 
   // stakes
 
-  function isStaked(uint256 tokenId) public override view returns (bool) {
+  function isStaked(uint256 tokenId) public view override returns (bool) {
     return staked[tokenId] != address(0);
   }
 
-  function getStaker(uint256 tokenId) external override view returns (address) {
+  function getStaker(uint256 tokenId) external view override returns (address) {
     return staked[tokenId];
   }
 
@@ -162,6 +162,4 @@ contract SuperpowerNFTBase is
   }
 
   // manage transfer
-
-
 }

--- a/contracts/WhitelistSlot.sol
+++ b/contracts/WhitelistSlot.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+import "./SuperpowerNFT.sol";
+
+contract WhitelistSlot is ERC1155, Ownable {
+  using Address for address;
+
+  constructor() ERC1155("") {}
+
+  mapping(address => uint256) private _burners;
+
+  modifier onlyBurner(uint256 id) {
+    require(_burners[_msgSender()] == id, "Not the final NFT");
+    _;
+  }
+
+  function setURI(string memory newUri) public onlyOwner {
+    _setURI(newUri);
+  }
+
+  function setBurnerForID(address burner, uint256 id) external onlyOwner {
+    require(burner.isContract(), "WhitelistSlot: burner not a contract");
+    _burners[burner] = id;
+  }
+
+  function getIdByBurner(address burner) public view returns(uint) {
+    return _burners[burner];
+  }
+
+  // airdropped to wallets to be whitelisted
+  function mintBatch(
+    address to,
+    uint256[] memory ids,
+    uint256[] memory amounts,
+    bytes memory data
+  ) public onlyOwner {
+    _mintBatch(to, ids, amounts, data);
+  }
+
+  function burn(
+    address account,
+    uint256 id,
+    uint256 value
+  ) public virtual onlyBurner(id) {
+    _burn(account, id, value);
+  }
+}

--- a/contracts/interfaces/ISuperpowerNFTBase.sol
+++ b/contracts/interfaces/ISuperpowerNFTBase.sol
@@ -13,6 +13,7 @@ interface ISuperpowerNFTBase {
   function isStaked(uint256 tokenID) external view returns (bool);
 
   function getStaker(uint256 tokenID) external view returns (address);
+
   function setPool(address pool) external;
 
   function removePool(address pool) external;


### PR DESCRIPTION
Adding a WhitelistSlot contract, as standard ERC1155.
The flow in case of turfs and farms:
* Owner set up a Farm NFT in WhitelistSlot: Farm NFT has ID 1
* Owner set configure the WhitelistSlot in the Farm NFT
* Owner batch-mints whitelisted SFT to buy Farm NFT
* During the purchase process, the `mint` function in the Farm, checks if the recipient has enough slots and reverts if not. If the user has enough WL slots, it mints the tokens and calls WhitelistSlot to burn the minted amount.

TODO: add specific tests.