### PR TITLE
add missing lib library @ndujalabs/attributable

### DIFF
--- a/contracts/NftFactory.sol
+++ b/contracts/NftFactory.sol
@@ -63,7 +63,7 @@ contract NftFactory is UUPSUpgradableTemplate {
   error InconsistentArrays();
   error RepeatedAcceptedToken();
   error InvalidAmountForSale();
-  error OnlyOneTokeForTransactionInPublicSale();
+  error OnlyOneTokenForTransactionInPublicSale();
 
   struct Sale {
     uint16 amountForSale;
@@ -324,7 +324,7 @@ contract NftFactory is UUPSUpgradableTemplate {
       if (_wl.balanceOf(_msgSender(), sales[nftId].whitelistedId) < amount) revert NotEnoughWLSlots();
       tokenAmount = getWlPrice(nftId, paymentToken);
     } else {
-      if (amount > 1) revert OnlyOneTokeForTransactionInPublicSale();
+      if (amount > 1) revert OnlyOneTokenForTransactionInPublicSale();
       tokenAmount = getPrice(nftId, paymentToken);
     }
     proceedsBalances[paymentToken] += tokenAmount;

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   },
   "lint-staged": {
     "*.js": "prettier --write"
+  },
+  "dependencies": {
+    "@ndujalabs/attributable": "^0.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,11 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@ethersproject/contracts': ^5.6.2
-  '@ndujalabs/attributable': ^0.0.3
-  '@ndujalabs/erc721playable': 0.6.1
-  '@ndujalabs/lockable': ^0.0.2
-  '@ndujalabs/wormhole-tunnel': 0.4.0
-  '@ndujalabs/wormhole721': ^0.5.3
+  '@ndujalabs/attributable': ^0.0.4
   '@nomiclabs/hardhat-ethers': ^2.0.3
   '@nomiclabs/hardhat-etherscan': ^2.1.8
   '@nomiclabs/hardhat-waffle': ^2.0.1
@@ -36,16 +32,13 @@ specifiers:
   require-or-mock: ^0.2.1
   solhint: ^3.3.6
   solidity-coverage: ^0.7.21
-  soliutils: 0.0.6
   typescript: ^4.7.3
+
+dependencies:
+  '@ndujalabs/attributable': 0.0.4
 
 devDependencies:
   '@ethersproject/contracts': 5.6.2
-  '@ndujalabs/attributable': 0.0.3
-  '@ndujalabs/erc721playable': 0.6.1
-  '@ndujalabs/lockable': 0.0.2
-  '@ndujalabs/wormhole-tunnel': 0.4.0
-  '@ndujalabs/wormhole721': 0.5.3
   '@nomiclabs/hardhat-ethers': 2.0.4_ethers@5.5.4+hardhat@2.8.3
   '@nomiclabs/hardhat-etherscan': 2.1.8_hardhat@2.8.3
   '@nomiclabs/hardhat-waffle': 2.0.2_6oy2mnnnyf6xpql55mxsdlbst4
@@ -75,7 +68,6 @@ devDependencies:
   require-or-mock: 0.2.1
   solhint: 3.3.7
   solidity-coverage: 0.7.21
-  soliutils: 0.0.6
   typescript: 4.7.3
 
 packages:
@@ -776,35 +768,9 @@ packages:
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
     dev: true
 
-  /@ndujalabs/attributable/0.0.3:
-    resolution: {integrity: sha512-gubxCQ+j9n3kdG4InaA6qbGI9Qs/MQxRn7qzRq2OI7u7DDPwp5K3hh2Lf45IoryTeQObyVeBqymb2JKQQcbtIw==}
-    dev: true
-
-  /@ndujalabs/erc721playable/0.6.1:
-    resolution: {integrity: sha512-UCUzwJnqOj9guarHQNpJ+xrvwQU/iDiwgLWrJuTTnQR+C4a3dy5rp1Mk190ia9ZVujCDTkfEz/pDb8cNH7aP+w==}
-    dependencies:
-      '@openzeppelin/contracts': 4.5.0
-      '@openzeppelin/contracts-upgradeable': 4.5.0
-    dev: true
-
-  /@ndujalabs/lockable/0.0.2:
-    resolution: {integrity: sha512-gck3BN+ul4aalrM8srCpdkyLKUID4JelJ0R6Sr6zfTqUaEIgyJvf8rwwyyYv637mJPcNJbdIvlH2YbDl28aYwQ==}
-    dev: true
-
-  /@ndujalabs/wormhole-tunnel/0.4.0:
-    resolution: {integrity: sha512-OpmaD2vRzkpcyUgKuE9Uc2oFs9gt0AWGyHMjrmNRb6sNt/DyZzwH/rXyVxYBEaLbjqb/3V8F05vpbWzyTgkmFA==}
-    dependencies:
-      '@openzeppelin/contracts': 4.5.0
-      '@openzeppelin/contracts-upgradeable': 4.5.0
-    dev: true
-
-  /@ndujalabs/wormhole721/0.5.3:
-    resolution: {integrity: sha512-JvNr10alOFqxOWC9UICXpQvKaY+zkYNnTtJy1BvJWBGSLy7Nv25NgPhRhVq1dpdSmXpkctjlvG/YVAZqePlHnA==}
-    dependencies:
-      '@ndujalabs/wormhole-tunnel': 0.4.0
-      '@openzeppelin/contracts': 4.5.0
-      '@openzeppelin/contracts-upgradeable': 4.5.0
-    dev: true
+  /@ndujalabs/attributable/0.0.4:
+    resolution: {integrity: sha512-XsRV36KGIc9e9XVSGoaxHsKRoS7RIyS4WD31Srv0hA9G5ocMgZO3kTUodcUOfoL/oGHaJuv2ks24ByC/Rpmfmg==}
+    dev: false
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -9135,13 +9101,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: true
-
-  /soliutils/0.0.6:
-    resolution: {integrity: sha512-2JNbZ3K0D9WUkauhaRIp1m5AoPbOw2VFoDWipyrF8JpjvmCs1ZEd7n6u4SeUR4/skd8o5dTY/guW6O9j0EBzVw==}
-    dependencies:
-      '@openzeppelin/contracts': 4.5.0
-      '@openzeppelin/contracts-upgradeable': 4.5.0
     dev: true
 
   /source-map-resolve/0.5.3:

--- a/test/NftFactory.test.js
+++ b/test/NftFactory.test.js
@@ -44,7 +44,7 @@ describe("NftFactory", function () {
 
     await farm.mint(owner.address, 3);
 
-    busd = await deployUtils.deployProxy("SeedTokenMock");
+    busd = await deployUtils.deployProxy("BUSDMock");
     await busd.deployed();
     await busd.mint(whitelisted.address, usdAmount);
     await busd.mint(notWhitelisted.address, usdAmount);
@@ -148,6 +148,11 @@ describe("NftFactory", function () {
       )
         .to.emit(turf, "Transfer")
         .withArgs(whitelisted.address, notWhitelisted.address, 1);
+    });
+
+    it("should get symbols of payment token", async function () {
+      expect(await factory.getPaymentTokenSymbol(seed.address)).equal("SEED");
+      expect(await factory.getPaymentTokenSymbol(busd.address)).equal("BUSD");
     });
 
     it("should get info about the tokens for sale", async function () {

--- a/test/NftFactory.test.js
+++ b/test/NftFactory.test.js
@@ -244,7 +244,7 @@ describe("NftFactory", function () {
       await increaseBlockTimestampBy((await getCurrentTimestamp()) + 1e4 + 10);
 
       await expect(factory.connect(notWhitelisted).buyTokens(1, busd.address, 3)).revertedWith(
-        "OnlyOneTokeForTransactionInPublicSale()"
+        "OnlyOneTokenForTransactionInPublicSale()"
       );
 
       expect(await factory.connect(notWhitelisted).buyTokens(1, busd.address, 1))


### PR DESCRIPTION
This commit fixes a build error when starting with a clean repo:
```
Error HH411: The library @ndujalabs/attributable, imported from contracts/mocks/PlayerMock.sol, is not installed. Try installing it using npm.
```
![Screen Shot 2022-12-14 at 7 24 05 AM](https://user-images.githubusercontent.com/46958/207521829-113fc9ac-4b47-4829-947b-98bf26bf739f.png)

Note: the dependency was defined in the `pnpm-lock.yaml` file but not in the `package.json` file, 