### PR TITLE
Update dependencies

### DIFF
--- a/contracts/SuperpowerNFT.sol
+++ b/contracts/SuperpowerNFT.sol
@@ -102,6 +102,7 @@ abstract contract SuperpowerNFT is ISuperpowerNFT, SuperpowerNFTBase {
   }
 
   function endMinting() external override onlyOwner {
+    maxSupply = nextTokenId - 1;
     _mintEnded = true;
   }
 

--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -111,7 +111,7 @@ abstract contract SuperpowerNFTBase is
     address to,
     uint256 tokenId
   ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
-    if (isLocked(tokenId)) {
+    if (locked(tokenId)) {
       revert LockedAsset();
     }
     super._beforeTokenTransfer(from, to, tokenId);
@@ -208,7 +208,7 @@ abstract contract SuperpowerNFTBase is
   // The owner keeps the ownership of it and can use that, for example,
   // to access services on Discord via Collab.land verification.
 
-  function isLocked(uint256 tokenId) public view override returns (bool) {
+  function locked(uint256 tokenId) public view override returns (bool) {
     return _lockedBy[tokenId] != address(0);
   }
 
@@ -240,7 +240,7 @@ abstract contract SuperpowerNFTBase is
     uint256 balance = balanceOf(owner);
     for (uint256 i = 0; i < balance; i++) {
       uint256 id = tokenOfOwnerByIndex(owner, i);
-      if (isLocked(id)) {
+      if (locked(id)) {
         return true;
       }
     }
@@ -266,7 +266,7 @@ abstract contract SuperpowerNFTBase is
 
   // emergency function in case a compromised locker is removed
   function unlockIfRemovedLocker(uint256 tokenId) external override onlyOwner {
-    if (!isLocked(tokenId)) {
+    if (!locked(tokenId)) {
       revert NotLockedAsset();
     }
     if (_lockers[_lockedBy[tokenId]]) {
@@ -285,14 +285,14 @@ abstract contract SuperpowerNFTBase is
   // OpenZeppelin best practices, avoid the user to spend useless gas.
 
   function approve(address to, uint256 tokenId) public override(IERC721Upgradeable, ERC721Upgradeable) {
-    if (isLocked(tokenId)) {
+    if (locked(tokenId)) {
       revert LockedAsset();
     }
     super.approve(to, tokenId);
   }
 
   function getApproved(uint256 tokenId) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (address) {
-    if (isLocked(tokenId)) {
+    if (locked(tokenId)) {
       return address(0);
     }
     return super.getApproved(tokenId);
@@ -323,7 +323,7 @@ abstract contract SuperpowerNFTBase is
     bytes32 recipient,
     uint32 nonce
   ) public payable override returns (uint64 sequence) {
-    if (isLocked(tokenID)) revert LockedAsset();
+    if (locked(tokenID)) revert LockedAsset();
     return super.wormholeTransfer(tokenID, recipientChain, recipient, nonce);
   }
 

--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -165,7 +165,10 @@ abstract contract SuperpowerNFTBase is
     override(Wormhole721Upgradeable, ERC721Upgradeable, ERC721EnumerableUpgradeable)
     returns (bool)
   {
-    return super.supportsInterface(interfaceId);
+    return
+      interfaceId == type(IAttributable).interfaceId ||
+      interfaceId == type(ILockable).interfaceId ||
+      super.supportsInterface(interfaceId);
   }
 
   function _baseURI() internal view virtual override returns (string memory) {

--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -53,6 +53,7 @@ abstract contract SuperpowerNFTBase is
   error AssetDoesNotExist();
   error AlreadyInitiated();
   error NotTheAssetOwner();
+  error NotTheAssetOwnerNorTheGame();
   error PlayerAlreadyAuthorized();
   error PlayerNotAuthorized();
   error FrozenTokenURI();
@@ -136,8 +137,8 @@ abstract contract SuperpowerNFTBase is
   }
 
   function initializeAttributesFor(uint256 _id, address _player) external override {
-    if (ownerOf(_id) != _msgSender()) {
-      revert NotTheAssetOwner();
+    if (ownerOf(_id) != _msgSender() && game != _msgSender()) {
+      revert NotTheAssetOwnerNorTheGame();
     }
     if (_tokenAttributes[_id][_player][0] > 0) {
       revert PlayerAlreadyAuthorized();

--- a/contracts/interfaces/ILockable.sol
+++ b/contracts/interfaces/ILockable.sol
@@ -14,7 +14,7 @@ interface ILockable {
   event Unlocked(uint256 tokendId);
 
   // tells if a token is locked
-  function isLocked(uint256 tokenID) external view returns (bool);
+  function locked(uint256 tokenID) external view returns (bool);
 
   // tells the address of the contract which is locking a token
   function lockerOf(uint256 tokenID) external view returns (address);

--- a/scripts/data/freeFarmWinners.json
+++ b/scripts/data/freeFarmWinners.json
@@ -1,866 +1,218 @@
 [
-  {
-    "wallet": "0x3487bA6A9c9FEA8AfAb35ebdF48B3A27532B7915",
-    "quantity": 14
-  },
-  {
-    "wallet": "0x88FeaD4cBc338F54C6a1517303cf79B3a03D7A2b",
-    "quantity": 8
-  },
-  {
-    "wallet": "0xF153BA46b70363A887ed7cddf87fbcbf2005D621",
-    "quantity": 6
-  },
-  {
-    "wallet": "0x4eF6511BbbEcB6a0F663638cF22381364763FD71",
-    "quantity": 5
-  },
-  {
-    "wallet": "0xbd101FFfAC618cc704F005315143dd63b445C5E7",
-    "quantity": 4
-  },
-  {
-    "wallet": "0xAC8869fcFBdEd40cb65450Abd4DB1A9e380aC7DD",
-    "quantity": 3
-  },
-  {
-    "wallet": "0x1f15d72245348cf28d060e5BE2eD25a948B2f222",
-    "quantity": 3
-  },
-  {
-    "wallet": "0xC485EE59d1D69f44d87c0545Ca1c641E05d04a76",
-    "quantity": 3
-  },
-  {
-    "wallet": "0x079f0F0423b181EedC71e9b2eD6b15B1d957c5Ac",
-    "quantity": 3
-  },
-  {
-    "wallet": "0x29895a3092Cbe1dBb7f2e65358978747341dbf01",
-    "quantity": 3
-  },
-  {
-    "wallet": "0xE8C836220F0E7f75DE25108027fBf65559DEd97E",
-    "quantity": 3
-  },
-  {
-    "wallet": "0x1e00B459fbdD319ea26e8D764ffd3c968C9d2E34",
-    "quantity": 3
-  },
-  {
-    "wallet": "0x0cd24d1537568f82237AC7d076D9418dc06b79d6",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xfaCAA385E2E81623C8cADA6d847aBf0814624b52",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xbB7DDaB6fD9B3A3c5f959cf2F7dB69acbe54c184",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xDa1EC4dA97019972759FedA1285878b97FDCC014",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x928c7D940ceCEd2f9AC6bAba5f582B18Ec1C7aBF",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x2d51caB9CE3dBACDA14aa65C5236D73b583bd156",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x8ee08C2ABB76488793b3204E75a4FAecd611E59F",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xbc8E4C006Bd1B96C1a50E8727F0b10874e6b261E",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x3aBcB5d5FB4044620c319bB63c5540a04e024AA1",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x2B08254f95422d7FdBfDE173E453e1F7e31C405B",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x18e3398cAd87b063817B45D21684aF908e207468",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x233A515c1c3Af772509fB14cCa5F37072aa2a070",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xDCF723610fdeB412A9Fe17AE9C2df98c2CbCA10F",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xd341db5BB6176bEDB6c3e62Aa5CC07088325b7aF",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xeEF94beD5a0C474794DB4bd2f28f3fe705cDEae4",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xb91bBdE050F65b0334aaD44ff05898F30daa3875",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x38cA36df97De1a5663342B832481D94355ac9D27",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x9B2b533Bc29e7555DF042C58415495812D95048b",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xf65d2EFc1fDA19847Fd82a48A122B73f0e3B84D0",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xf28BdE07be3517618913438F4f4448Aba4A816D9",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xF89d3C2D33835992b48F37205E32EA68c7680dF4",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x7fDbdc0C1035EdA3C53F14EEb5bc4C5C0997B9c1",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x0A2809076b654D6951E41b03568F16717a50Af4A",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x94bd3400e28a715e8C078117B61Ecf678139a294",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x833186a107A881e7A39DA9D88999f55dc7350CBe",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x2829DFDC378C507c3B2D80EF5f99B1F199573FF3",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x277B457fcCd42b7d1ab0e67d79b49ddf749546a6",
-    "quantity": 2
-  },
-  {
-    "wallet": "0x59FC43183C6b3E874d9F7eeaF79A0F708A8Cc08D",
-    "quantity": 2
-  },
-  {
-    "wallet": "0xd04111Fc8F4e432CF41166Bacb88994F7cbF3ff5",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x9cc5EA498eA8466b9BC6bBff1775B81Bbe1E6719",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xeCeCd4f560161e0A12C8673DE3073aAEB3c47e1D",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xcEC87a49Fec7aA9e2A4AB8Db6C1C5056f3511249",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xae77f2A6D9E52db6a9761F13200093868aE06255",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xCa27f3B574d9AeA4123cCC397ce4110b48CD1521",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x2d98E26d0C4555C6Ca8BeA476134E5B899b6838d",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xc0Cf3f7ab953fE6ad5d90E4396601DA6F5C3c35b",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xA3b0347C211aCD972891803a49Ab28D632Eabf75",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xA60A3b210e9776B223e14B51C4285e034715C9b2",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x131cD5E746Fa428C80b34A70b136C36722C613ae",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x9f85969E627B8E6CEA07AF65ea2DFFCacFd76556",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xB981290d9d804075986482F0302c03A3Cd2aFf32",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x84bA38696f4F2dbCb88Ec2C5F82d24A074d2E6fe",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xeacb9f0d1C8186eb2aCa48a89Ee01ff6De3bc28a",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xdC9C1e1d7d8AB77aA0090fB981a811f3E5127484",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xfa98bCb727c284897f4fD75BEabC9201011D0e93",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf030FEe72b6dCA0367ceBb133d6E751Ae27d6a76",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xc42adD8541a7111bb53D1d0C7f379a0d981c9a98",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x78Ffa27D122043874DBE879B7173180FeD3ccf1D",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1fEAb880bB6E81761920C7314BF1789d3325Cd33",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xBcC13DdAc2a722afD9348ccfD31fdC95F79a6277",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x529051F57Fa91c60044d4C523A4A24B058b8278A",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x98C7e670D808E02a2fd4099ADc52987c2f43d1aA",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xB78AB8c7268EC59DD324a2E3BA6A359c20a54D46",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x6B3FE9b09B65AD7235AC8265B3B51699F2813e9C",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1db36587e47a48D9534D5a4a5dBB6d10C8726db9",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x81e3C9dED64CAF37ee5fFd643637E1a97CD64F5f",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xBAfD1aF4F0CEa198396d5a3087219497Ff7dcaB0",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x9b136F12d78f68b078d80e242606422c64Ada80C",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xD4852b7419F58793EbBE66F2c1382a10c8f6A9FF",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x15938984172df4ee65582c697316B08a5e6de452",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x8Ed1bdB5bd669Be2121c48A6D178CAB35BCb43d0",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x97e142399C4CbA7B4d36b40aa767F9643B34978d",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xA697765F211951c6dA378Dae4D69BA0a39881bFb",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x4D1750f3aB3e746538F302b9dEd3Db31317B64A7",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xae74f7B79D3e32A819675403e54A550824C0bF02",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x348AaC0a9935277784f9fF6fACBe4B202f02e6a1",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x9065BEE921567772854C38b826a794349f5eE2B5",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7764F37E255B12B02e6936B7a060ea73EC45B431",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x50e560e7cB99e321c110EEE560a2Da8364a290F9",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x4c9C3626Cf1828Da7b58a50DC2F6AA2C4546609e",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x4f73E33721eDc1EcAe5A45261fBe6C0bC4Fb1685",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x6a74DF3e3B2BBC7D1BC4ceF29543fc41C86c452e",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf628cE0687d35089FBef40aD3680356E7B638863",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x86E4F4AE2e09bcEc1dFDeeAa7c378821e56b7b3e",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xb299D1c0904691B3EBCB337293bd5eD657036eC1",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xB885Cb7070A084A4Ae2de3F8507927fc213998DF",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xF22Ea607A889EB21451e3f52C9D191da49Dd8836",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5b0d1192cCf825DB63D9371d4380f880898e3354",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xC2978441F46a76c60e0cd59E986498b75a40572D",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1A5A74DF8E578CaFc56c99C655fB8eAF6692Be6e",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x59c33EF5CF07e2b7df5d8Ac8Ee931F0E39047A23",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xeEa1DF0EF4E90154fC893503c5F05c30bBD4e885",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xAEFB17544Eebfd18e2F5FdFDa43B5Be69Baf8246",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x98FD7670F441E3de7f071C0aCFb1Fd567998C8d2",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x07e7CBa9F29c7732F1c87e018fEBbD13E2f264A5",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x96DE627bE6262aD2E19553824aAD1aF6Ba1eBe9B",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xa2225b86CCB530ac9a81D41a3d17ab643A9f7c8C",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xb1e5B583780d2D97B0E75F3C58dc0751444871f1",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xd9eeb6ac27c3A5eE37F967EEFBd5D7A33bE5ebD2",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1E545bbb0cC33163fED5339f7a72167B53EdA13a",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x73E9411A0e782b62887c6A3423aDFAFd747301a8",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x253a41571830Dca332724DFF29Afb8960ffcCDf6",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xF6C9692A490BAf4b4dfa9BD1c9fc4438c38b5321",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x777d92Fcb83Ca9131B05ce579D9A951019c4Ca5c",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x71039d40ad2123b23FDFfe56453E903a515E5ac5",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x38671F9A37bD37EA52aD63182D3Ff6a64e2692D6",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x8Fc87c199203332c1cc43430b9FaD2B1868E44D0",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3F6D62DA04f6B3F3fc0dDeFeB17543fAc278e383",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xF79765D064B86648C7C01F55f9eCB5ec5D3A7d4b",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1fDbFfD0d8e237E64E68A904c2a6F447a1aD5C90",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x6707b67dA257d77DDAe75D24476436e608E45c09",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xe481BD03D8fAF78cc18bDD0118073007EED82f67",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3De6A9B46E4840F5D235626CF07fE48a7e044fB0",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x2EFEEb8D5Df533565a44F1A1ACf12Cd5B46196CF",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3dC7F8850CbfE558eeE8442d553fdE8eb49DcF5D",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xa728ba7C90AFC95423aA00bb9bbcBe68fd80be5d",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf5Fc69ECd8DdaAba72B73830b02592200bB78918",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5d73eEe7E0d8C955F9d442B12d463B4c5B8e7dC3",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x77Ed421D98BF2fe6542Ae6EEeD341B759C6E764a",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xe1645f135525ba04C90235718b4C33c995253e16",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x4Ed78BC2FCFF4441dAb71fc8aAB65FF94D18dB15",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf02aaeA623E7C0AC779D68d734BEd438e67775Eb",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x245Ca790317489C2252F63b95Dab698C7955a9A3",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xDCC9F7368EE6636FC2f7A02b713072D75474D9E6",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf1439E1D1EfB1a90983a6Ae306cE42B6921e093b",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5C4e877b3f410d4c505be0D8D3d77cC34cEae548",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7BC6230B10824e28c57aE71fC98d80A4988F11a6",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x78834B429d868108d8f9b4dB9B0348EF2BC23257",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5D20e6c0DB887B5c3281EdfCe5BB7677565e2B8f",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xA6A88909c58640deBDf86FdC7179A25e036378b3",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xC4f2C31F364423c3BFfd766c9B320f5eC64da64e",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x43Ec5640E18F7384761d8817AA55d38C9a03D855",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xeFfeC91cF9CEd27dF6dD9eBC9D465E5D14db2618",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3164ed5B9D37Ac9619aC5895CA33F308aB02a053",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x310115b783a94C6Fc371Ed03eB7d3fe15b1D02e2",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x8F42E67db71a3542E4398b138C5CE8Aaad694aD6",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xD5c69ecCc7d8e0c124c205328cC6CEC584b4E15A",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7aDBee9c890eb294A816a0aAc5507cc1DEF53598",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xcAC3dce2CaB052B903dA719F99Ed182bf7A22fDb",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1c16BE3c5D62842D950eFA6675214aEca45ABb1f",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3d78BDB36f63aFA32973bF19F5c689bEA9627F03",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x9c709C02b87072C8599c5416617FD259D334EEf2",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1643635228eda7c2c82F05B520FE755EabAed547",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x935002727A6EBBcaf01a0039DB0e6B1f9C175f0b",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x556501B3A439f105f14ddeb5D96a892f9E3502CC",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3500e121e102C88cE7cb92dd4A8B074CCF704560",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1e57EBeA7b301877B925551dB9c2eB2917537681",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xd853eb73b3657CbCD32438289F2C89A4b487FDda",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5b49F719262FFf473628E2223971a0Ba2cafa62a",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x502a4beC9AEb8Afa10408FcCb89361FB206DaB78",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x682955aC3cc48433060e40200E214Bdca6b40Dd4",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xC7DcfC4873f4DA211da8C255c9F1d2B18713845F",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xd88DFEa2ddB0d73C23A3710bCb572fe58589eC76",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xac905fd0B601bEb21E1cDDc9d6Aea64Bebce855a",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x750554C8CD238765FCDe9467E33E6e6d595265F2",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x0351788F4e05FF3C40F601B5FA6ba4B6E44633E5",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x033f29B41D74E548967B9eA9bAa004DA704161fb",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xC1Eab99C6F2cd06ad1C60e5b642BE32C3c874613",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x06Df3F02E84F7034CF70f52cdf5Cdc0Ab02F6Fea",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xb6314005148f51d6B1340B7f021DB8679bd85596",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xC9DC2b2C152229f953FDcc65F157dfce38cd2475",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xbBFC75D703e19a1222F80Eb943a56752b5cf38bf",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x021D3D3a143c84256ce8e00db8813f7E8d6d56EB",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x8ccB4FeE9938B91D3f723D66e71948ee08cdD0cD",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x6c877fFf366532D828018e77498AaAAd71464724",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x32B89dEa9Dfbcf19760CbeA6eB52261C6c2642EC",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x2beed6BbE9B466477C495e24cfD0302C7eC7a00e",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xAe250038133696ACCcBf24B28D04DCdd9090D256",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xE131b551994f56d1CCa7bDaaa18E94Fbf80cef7E",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x95425e5abb5CEce0C5653DD77bE02b7913e53488",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xedCD8F695eEf2BFBDa6b60d7BB520150FaAdc4B8",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7ab1475ab635B6b28cb705B58B77CBFcb9f2B4ec",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7080320bED0ca0d46585aA8A81bA66880650B720",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xE147f089D6232d34d25659A2e41Eb2B5C52aE643",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7cA4c6dD8e8754e9A767D21e0542549dA58dd374",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5AcBD3b267d1D5e95E26ED97C1856c6Bb4BE8f28",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xE162c3558d67c79C039Db752F0efE0C0E13cFf5F",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xcaAA82aE25A696CDc7fA4da3240084f3Ceb83F4b",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x49E6E064101034e0E67f43f80F52Fee8c3a1d761",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xe28d7E87b0dBda55B5560CB2fc3409CD7d4631DD",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x41868152a143ECeAF87C05D8ae86FDc8Cb38De68",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x11bD7ec08f4eadAbb7E74001D399F15CacFc99b6",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf0deDE477E1F4283C8Bd47d8D7E21Ee7C7922E12",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x7948cE471b0838F00BC9926b4625075fd702Be63",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xaaB86239606e1755abDe3C0cCe833340b2A88c72",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x4088d02D9198FC9471f37ce1789E2c6c9658A9ce",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xf4c7db023BF4A3046C6b8fF10D40e8f7C0223c97",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x750D8C84cE9FD52677e49710b93057F0fD6f29Cd",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x3bAa2ABf45A8146EeA9Da9C4B0D1a58f22238525",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xaB6Bb077306a3e905E84329996902e0C7ef4a721",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x5a33cE0e4B32e592728DC10FD4C2E20d13A8F5dF",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xdC8EEB01df612a0cCc74E8eed362129bC2186C8a",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x21b43179E68cD635Cf5fb19538B97C5648dBf685",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xDc4A381246357db903B6c53D1a9A9dd4fE878271",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xbE95f030Fe39bdb9Ff8fC249Ac253785557060bd",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x521E6B622a198B91Ac27CD44Fd2264E48b3cF41D",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xC261924c9EB7b02EFC14027B707b7F2daf890D27",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xcDd4afF32c042F33867294BE96e7013E69a34e0B",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x8F564a2D058171a20CbFBd48EFEe785c77F4Cea9",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x0e5222F40A40E3603895B55c54a93EDD2Da24529",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xdDD8cbdBF508a7aaE565026D607097A282916362",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xe2443169f25b4a4DEE3A29F7326c1dDCeaFFCA63",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x05d03d54772eF6420C56a680A5F5b3DEab6F5997",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x78eE7327457EDFa8A1D9f067db64E755EAeEDe6E",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x381712d37b333164aEe06f26293a45339359c140",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xFF997fA97519563738705B72fFB97Da25601e604",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x116f1787058A4c9e5c8A8Bd6E4D311EF3C99afDD",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1cdA720e9E10510D6214CB83a72a9A608b558C86",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xc17A878D9c03B8191275F85fd8f4dfb76137D807",
-    "quantity": 1
-  },
-  {
-    "wallet": "0xB5C6d75678927DdF54B2ea25B87bA5f3588B23cC",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x26eF425B91Cc50168Ce65349CB6d35AAb4f1d912",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x318F66a11f2eC1c1B9Dbe8EB4CdCaC59Bf1a75CC",
-    "quantity": 1
-  },
-  {
-    "wallet": "0x1DA4400316275C34f7d4Ff5448afA461AB386650",
-    "quantity": 1
-  }
+  {"wallet": "0x3487bA6A9c9FEA8AfAb35ebdF48B3A27532B7915", "quantity": 14, "done": true},
+  {"wallet": "0x88FeaD4cBc338F54C6a1517303cf79B3a03D7A2b", "quantity": 8, "done": true},
+  {"wallet": "0xF153BA46b70363A887ed7cddf87fbcbf2005D621", "quantity": 6, "done": true},
+  {"wallet": "0x4eF6511BbbEcB6a0F663638cF22381364763FD71", "quantity": 5, "done": true},
+  {"wallet": "0xbd101FFfAC618cc704F005315143dd63b445C5E7", "quantity": 4, "done": true},
+  {"wallet": "0xAC8869fcFBdEd40cb65450Abd4DB1A9e380aC7DD", "quantity": 3, "done": true},
+  {"wallet": "0x1f15d72245348cf28d060e5BE2eD25a948B2f222", "quantity": 3, "done": true},
+  {"wallet": "0xC485EE59d1D69f44d87c0545Ca1c641E05d04a76", "quantity": 3, "done": true},
+  {"wallet": "0x079f0F0423b181EedC71e9b2eD6b15B1d957c5Ac", "quantity": 3, "done": true},
+  {"wallet": "0x29895a3092Cbe1dBb7f2e65358978747341dbf01", "quantity": 3, "done": true},
+  {"wallet": "0xE8C836220F0E7f75DE25108027fBf65559DEd97E", "quantity": 3, "done": true},
+  {"wallet": "0x1e00B459fbdD319ea26e8D764ffd3c968C9d2E34", "quantity": 3, "done": true},
+  {"wallet": "0x0cd24d1537568f82237AC7d076D9418dc06b79d6", "quantity": 2, "done": true},
+  {"wallet": "0xfaCAA385E2E81623C8cADA6d847aBf0814624b52", "quantity": 2, "done": true},
+  {"wallet": "0xbB7DDaB6fD9B3A3c5f959cf2F7dB69acbe54c184", "quantity": 2, "done": true},
+  {"wallet": "0xDa1EC4dA97019972759FedA1285878b97FDCC014", "quantity": 2, "done": true},
+  {"wallet": "0x928c7D940ceCEd2f9AC6bAba5f582B18Ec1C7aBF", "quantity": 2, "done": true},
+  {"wallet": "0x2d51caB9CE3dBACDA14aa65C5236D73b583bd156", "quantity": 2, "done": true},
+  {"wallet": "0x8ee08C2ABB76488793b3204E75a4FAecd611E59F", "quantity": 2, "done": true},
+  {"wallet": "0xbc8E4C006Bd1B96C1a50E8727F0b10874e6b261E", "quantity": 2, "done": true},
+  {"wallet": "0x3aBcB5d5FB4044620c319bB63c5540a04e024AA1", "quantity": 2, "done": true},
+  {"wallet": "0x2B08254f95422d7FdBfDE173E453e1F7e31C405B", "quantity": 2, "done": true},
+  {"wallet": "0x18e3398cAd87b063817B45D21684aF908e207468", "quantity": 2, "done": true},
+  {"wallet": "0x233A515c1c3Af772509fB14cCa5F37072aa2a070", "quantity": 2, "done": true},
+  {"wallet": "0xDCF723610fdeB412A9Fe17AE9C2df98c2CbCA10F", "quantity": 2, "done": true},
+  {"wallet": "0xd341db5BB6176bEDB6c3e62Aa5CC07088325b7aF", "quantity": 2, "done": true},
+  {"wallet": "0xeEF94beD5a0C474794DB4bd2f28f3fe705cDEae4", "quantity": 2, "done": true},
+  {"wallet": "0xb91bBdE050F65b0334aaD44ff05898F30daa3875", "quantity": 2, "done": true},
+  {"wallet": "0x38cA36df97De1a5663342B832481D94355ac9D27", "quantity": 2, "done": true},
+  {"wallet": "0x9B2b533Bc29e7555DF042C58415495812D95048b", "quantity": 2, "done": true},
+  {"wallet": "0xf65d2EFc1fDA19847Fd82a48A122B73f0e3B84D0", "quantity": 2, "done": true},
+  {"wallet": "0xf28BdE07be3517618913438F4f4448Aba4A816D9", "quantity": 2, "done": true},
+  {"wallet": "0xF89d3C2D33835992b48F37205E32EA68c7680dF4", "quantity": 2, "done": true},
+  {"wallet": "0x7fDbdc0C1035EdA3C53F14EEb5bc4C5C0997B9c1", "quantity": 2, "done": true},
+  {"wallet": "0x0A2809076b654D6951E41b03568F16717a50Af4A", "quantity": 2, "done": true},
+  {"wallet": "0x94bd3400e28a715e8C078117B61Ecf678139a294", "quantity": 2, "done": true},
+  {"wallet": "0x833186a107A881e7A39DA9D88999f55dc7350CBe", "quantity": 2, "done": true},
+  {"wallet": "0x2829DFDC378C507c3B2D80EF5f99B1F199573FF3", "quantity": 2, "done": true},
+  {"wallet": "0x277B457fcCd42b7d1ab0e67d79b49ddf749546a6", "quantity": 2, "done": true},
+  {"wallet": "0x59FC43183C6b3E874d9F7eeaF79A0F708A8Cc08D", "quantity": 2, "done": true},
+  {"wallet": "0xd04111Fc8F4e432CF41166Bacb88994F7cbF3ff5", "quantity": 1, "done": true},
+  {"wallet": "0x9cc5EA498eA8466b9BC6bBff1775B81Bbe1E6719", "quantity": 1, "done": true},
+  {"wallet": "0xeCeCd4f560161e0A12C8673DE3073aAEB3c47e1D", "quantity": 1, "done": true},
+  {"wallet": "0xcEC87a49Fec7aA9e2A4AB8Db6C1C5056f3511249", "quantity": 1, "done": true},
+  {"wallet": "0xae77f2A6D9E52db6a9761F13200093868aE06255", "quantity": 1, "done": true},
+  {"wallet": "0xCa27f3B574d9AeA4123cCC397ce4110b48CD1521", "quantity": 1, "done": true},
+  {"wallet": "0x2d98E26d0C4555C6Ca8BeA476134E5B899b6838d", "quantity": 1, "done": true},
+  {"wallet": "0xc0Cf3f7ab953fE6ad5d90E4396601DA6F5C3c35b", "quantity": 1, "done": true},
+  {"wallet": "0xA3b0347C211aCD972891803a49Ab28D632Eabf75", "quantity": 1, "done": true},
+  {"wallet": "0xA60A3b210e9776B223e14B51C4285e034715C9b2", "quantity": 1, "done": true},
+  {"wallet": "0x131cD5E746Fa428C80b34A70b136C36722C613ae", "quantity": 1, "done": true},
+  {"wallet": "0x9f85969E627B8E6CEA07AF65ea2DFFCacFd76556", "quantity": 1, "done": true},
+  {"wallet": "0xB981290d9d804075986482F0302c03A3Cd2aFf32", "quantity": 1, "done": true},
+  {"wallet": "0x84bA38696f4F2dbCb88Ec2C5F82d24A074d2E6fe", "quantity": 1, "done": true},
+  {"wallet": "0xeacb9f0d1C8186eb2aCa48a89Ee01ff6De3bc28a", "quantity": 1, "done": true},
+  {"wallet": "0xdC9C1e1d7d8AB77aA0090fB981a811f3E5127484", "quantity": 1, "done": true},
+  {"wallet": "0xfa98bCb727c284897f4fD75BEabC9201011D0e93", "quantity": 1, "done": true},
+  {"wallet": "0xf030FEe72b6dCA0367ceBb133d6E751Ae27d6a76", "quantity": 1, "done": true},
+  {"wallet": "0xc42adD8541a7111bb53D1d0C7f379a0d981c9a98", "quantity": 1, "done": true},
+  {"wallet": "0x78Ffa27D122043874DBE879B7173180FeD3ccf1D", "quantity": 1, "done": true},
+  {"wallet": "0x1fEAb880bB6E81761920C7314BF1789d3325Cd33", "quantity": 1, "done": true},
+  {"wallet": "0xBcC13DdAc2a722afD9348ccfD31fdC95F79a6277", "quantity": 1, "done": true},
+  {"wallet": "0x529051F57Fa91c60044d4C523A4A24B058b8278A", "quantity": 1, "done": true},
+  {"wallet": "0x98C7e670D808E02a2fd4099ADc52987c2f43d1aA", "quantity": 1, "done": true},
+  {"wallet": "0xB78AB8c7268EC59DD324a2E3BA6A359c20a54D46", "quantity": 1, "done": true},
+  {"wallet": "0x6B3FE9b09B65AD7235AC8265B3B51699F2813e9C", "quantity": 1, "done": true},
+  {"wallet": "0x1db36587e47a48D9534D5a4a5dBB6d10C8726db9", "quantity": 1, "done": true},
+  {"wallet": "0x81e3C9dED64CAF37ee5fFd643637E1a97CD64F5f", "quantity": 1, "done": true},
+  {"wallet": "0xBAfD1aF4F0CEa198396d5a3087219497Ff7dcaB0", "quantity": 1, "done": true},
+  {"wallet": "0x9b136F12d78f68b078d80e242606422c64Ada80C", "quantity": 1, "done": true},
+  {"wallet": "0xD4852b7419F58793EbBE66F2c1382a10c8f6A9FF", "quantity": 1, "done": true},
+  {"wallet": "0x15938984172df4ee65582c697316B08a5e6de452", "quantity": 1, "done": true},
+  {"wallet": "0x8Ed1bdB5bd669Be2121c48A6D178CAB35BCb43d0", "quantity": 1, "done": true},
+  {"wallet": "0x97e142399C4CbA7B4d36b40aa767F9643B34978d", "quantity": 1, "done": true},
+  {"wallet": "0xA697765F211951c6dA378Dae4D69BA0a39881bFb", "quantity": 1, "done": true},
+  {"wallet": "0x4D1750f3aB3e746538F302b9dEd3Db31317B64A7", "quantity": 1, "done": true},
+  {"wallet": "0xae74f7B79D3e32A819675403e54A550824C0bF02", "quantity": 1, "done": true},
+  {"wallet": "0x348AaC0a9935277784f9fF6fACBe4B202f02e6a1", "quantity": 1, "done": true},
+  {"wallet": "0x9065BEE921567772854C38b826a794349f5eE2B5", "quantity": 1, "done": true},
+  {"wallet": "0x7764F37E255B12B02e6936B7a060ea73EC45B431", "quantity": 1, "done": true},
+  {"wallet": "0x50e560e7cB99e321c110EEE560a2Da8364a290F9", "quantity": 1, "done": true},
+  {"wallet": "0x4c9C3626Cf1828Da7b58a50DC2F6AA2C4546609e", "quantity": 1, "done": true},
+  {"wallet": "0x4f73E33721eDc1EcAe5A45261fBe6C0bC4Fb1685", "quantity": 1, "done": true},
+  {"wallet": "0x6a74DF3e3B2BBC7D1BC4ceF29543fc41C86c452e", "quantity": 1, "done": true},
+  {"wallet": "0xf628cE0687d35089FBef40aD3680356E7B638863", "quantity": 1, "done": true},
+  {"wallet": "0x86E4F4AE2e09bcEc1dFDeeAa7c378821e56b7b3e", "quantity": 1, "done": true},
+  {"wallet": "0xb299D1c0904691B3EBCB337293bd5eD657036eC1", "quantity": 1, "done": true},
+  {"wallet": "0xB885Cb7070A084A4Ae2de3F8507927fc213998DF", "quantity": 1, "done": true},
+  {"wallet": "0xF22Ea607A889EB21451e3f52C9D191da49Dd8836", "quantity": 1, "done": true},
+  {"wallet": "0x5b0d1192cCf825DB63D9371d4380f880898e3354", "quantity": 1, "done": true},
+  {"wallet": "0xC2978441F46a76c60e0cd59E986498b75a40572D", "quantity": 1, "done": true},
+  {"wallet": "0x1A5A74DF8E578CaFc56c99C655fB8eAF6692Be6e", "quantity": 1, "done": true},
+  {"wallet": "0x59c33EF5CF07e2b7df5d8Ac8Ee931F0E39047A23", "quantity": 1, "done": true},
+  {"wallet": "0xeEa1DF0EF4E90154fC893503c5F05c30bBD4e885", "quantity": 1, "done": true},
+  {"wallet": "0xAEFB17544Eebfd18e2F5FdFDa43B5Be69Baf8246", "quantity": 1, "done": true},
+  {"wallet": "0x98FD7670F441E3de7f071C0aCFb1Fd567998C8d2", "quantity": 1, "done": true},
+  {"wallet": "0x07e7CBa9F29c7732F1c87e018fEBbD13E2f264A5", "quantity": 1, "done": true},
+  {"wallet": "0x96DE627bE6262aD2E19553824aAD1aF6Ba1eBe9B", "quantity": 1, "done": true},
+  {"wallet": "0xa2225b86CCB530ac9a81D41a3d17ab643A9f7c8C", "quantity": 1, "done": true},
+  {"wallet": "0xb1e5B583780d2D97B0E75F3C58dc0751444871f1", "quantity": 1, "done": true},
+  {"wallet": "0xd9eeb6ac27c3A5eE37F967EEFBd5D7A33bE5ebD2", "quantity": 1, "done": true},
+  {"wallet": "0x1E545bbb0cC33163fED5339f7a72167B53EdA13a", "quantity": 1, "done": true},
+  {"wallet": "0x73E9411A0e782b62887c6A3423aDFAFd747301a8", "quantity": 1, "done": true},
+  {"wallet": "0x253a41571830Dca332724DFF29Afb8960ffcCDf6", "quantity": 1, "done": true},
+  {"wallet": "0xF6C9692A490BAf4b4dfa9BD1c9fc4438c38b5321", "quantity": 1, "done": true},
+  {"wallet": "0x777d92Fcb83Ca9131B05ce579D9A951019c4Ca5c", "quantity": 1, "done": true},
+  {"wallet": "0x71039d40ad2123b23FDFfe56453E903a515E5ac5", "quantity": 1, "done": true},
+  {"wallet": "0x38671F9A37bD37EA52aD63182D3Ff6a64e2692D6", "quantity": 1, "done": true},
+  {"wallet": "0x8Fc87c199203332c1cc43430b9FaD2B1868E44D0", "quantity": 1, "done": true},
+  {"wallet": "0x3F6D62DA04f6B3F3fc0dDeFeB17543fAc278e383", "quantity": 1, "done": true},
+  {"wallet": "0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765", "quantity": 1, "done": true},
+  {"wallet": "0xF79765D064B86648C7C01F55f9eCB5ec5D3A7d4b", "quantity": 1, "done": true},
+  {"wallet": "0x1fDbFfD0d8e237E64E68A904c2a6F447a1aD5C90", "quantity": 1, "done": true},
+  {"wallet": "0x6707b67dA257d77DDAe75D24476436e608E45c09", "quantity": 1, "done": true},
+  {"wallet": "0xe481BD03D8fAF78cc18bDD0118073007EED82f67", "quantity": 1, "done": true},
+  {"wallet": "0x3De6A9B46E4840F5D235626CF07fE48a7e044fB0", "quantity": 1, "done": true},
+  {"wallet": "0x2EFEEb8D5Df533565a44F1A1ACf12Cd5B46196CF", "quantity": 1, "done": true},
+  {"wallet": "0x3dC7F8850CbfE558eeE8442d553fdE8eb49DcF5D", "quantity": 1, "done": true},
+  {"wallet": "0xa728ba7C90AFC95423aA00bb9bbcBe68fd80be5d", "quantity": 1, "done": true},
+  {"wallet": "0xf5Fc69ECd8DdaAba72B73830b02592200bB78918", "quantity": 1, "done": true},
+  {"wallet": "0x5d73eEe7E0d8C955F9d442B12d463B4c5B8e7dC3", "quantity": 1, "done": true},
+  {"wallet": "0x77Ed421D98BF2fe6542Ae6EEeD341B759C6E764a", "quantity": 1, "done": true},
+  {"wallet": "0xe1645f135525ba04C90235718b4C33c995253e16", "quantity": 1, "done": true},
+  {"wallet": "0x4Ed78BC2FCFF4441dAb71fc8aAB65FF94D18dB15", "quantity": 1, "done": true},
+  {"wallet": "0xf02aaeA623E7C0AC779D68d734BEd438e67775Eb", "quantity": 1, "done": true},
+  {"wallet": "0x245Ca790317489C2252F63b95Dab698C7955a9A3", "quantity": 1, "done": true},
+  {"wallet": "0xDCC9F7368EE6636FC2f7A02b713072D75474D9E6", "quantity": 1, "done": true},
+  {"wallet": "0xf1439E1D1EfB1a90983a6Ae306cE42B6921e093b", "quantity": 1, "done": true},
+  {"wallet": "0x5C4e877b3f410d4c505be0D8D3d77cC34cEae548", "quantity": 1, "done": true},
+  {"wallet": "0x7BC6230B10824e28c57aE71fC98d80A4988F11a6", "quantity": 1, "done": true},
+  {"wallet": "0x78834B429d868108d8f9b4dB9B0348EF2BC23257", "quantity": 1, "done": true},
+  {"wallet": "0x5D20e6c0DB887B5c3281EdfCe5BB7677565e2B8f", "quantity": 1, "done": true},
+  {"wallet": "0xA6A88909c58640deBDf86FdC7179A25e036378b3", "quantity": 1, "done": true},
+  {"wallet": "0xC4f2C31F364423c3BFfd766c9B320f5eC64da64e", "quantity": 1, "done": true},
+  {"wallet": "0x43Ec5640E18F7384761d8817AA55d38C9a03D855", "quantity": 1, "done": true},
+  {"wallet": "0xeFfeC91cF9CEd27dF6dD9eBC9D465E5D14db2618", "quantity": 1, "done": true},
+  {"wallet": "0x3164ed5B9D37Ac9619aC5895CA33F308aB02a053", "quantity": 1, "done": true},
+  {"wallet": "0x310115b783a94C6Fc371Ed03eB7d3fe15b1D02e2", "quantity": 1, "done": true},
+  {"wallet": "0x8F42E67db71a3542E4398b138C5CE8Aaad694aD6", "quantity": 1, "done": true},
+  {"wallet": "0xD5c69ecCc7d8e0c124c205328cC6CEC584b4E15A", "quantity": 1, "done": true},
+  {"wallet": "0x7aDBee9c890eb294A816a0aAc5507cc1DEF53598", "quantity": 1, "done": true},
+  {"wallet": "0xcAC3dce2CaB052B903dA719F99Ed182bf7A22fDb", "quantity": 1, "done": true},
+  {"wallet": "0x1c16BE3c5D62842D950eFA6675214aEca45ABb1f", "quantity": 1, "done": true},
+  {"wallet": "0x3d78BDB36f63aFA32973bF19F5c689bEA9627F03", "quantity": 1, "done": true},
+  {"wallet": "0x9c709C02b87072C8599c5416617FD259D334EEf2", "quantity": 1, "done": true},
+  {"wallet": "0x1643635228eda7c2c82F05B520FE755EabAed547", "quantity": 1, "done": true},
+  {"wallet": "0x935002727A6EBBcaf01a0039DB0e6B1f9C175f0b", "quantity": 1, "done": true},
+  {"wallet": "0x556501B3A439f105f14ddeb5D96a892f9E3502CC", "quantity": 1, "done": true},
+  {"wallet": "0x3500e121e102C88cE7cb92dd4A8B074CCF704560", "quantity": 1, "done": true},
+  {"wallet": "0x1e57EBeA7b301877B925551dB9c2eB2917537681", "quantity": 1, "done": true},
+  {"wallet": "0xd853eb73b3657CbCD32438289F2C89A4b487FDda", "quantity": 1, "done": true},
+  {"wallet": "0x5b49F719262FFf473628E2223971a0Ba2cafa62a", "quantity": 1, "done": true},
+  {"wallet": "0x502a4beC9AEb8Afa10408FcCb89361FB206DaB78", "quantity": 1, "done": true},
+  {"wallet": "0x682955aC3cc48433060e40200E214Bdca6b40Dd4", "quantity": 1, "done": true},
+  {"wallet": "0xC7DcfC4873f4DA211da8C255c9F1d2B18713845F", "quantity": 1, "done": true},
+  {"wallet": "0xd88DFEa2ddB0d73C23A3710bCb572fe58589eC76", "quantity": 1, "done": true},
+  {"wallet": "0xac905fd0B601bEb21E1cDDc9d6Aea64Bebce855a", "quantity": 1, "done": true},
+  {"wallet": "0x750554C8CD238765FCDe9467E33E6e6d595265F2", "quantity": 1, "done": true},
+  {"wallet": "0x0351788F4e05FF3C40F601B5FA6ba4B6E44633E5", "quantity": 1, "done": true},
+  {"wallet": "0x033f29B41D74E548967B9eA9bAa004DA704161fb", "quantity": 1, "done": true},
+  {"wallet": "0xC1Eab99C6F2cd06ad1C60e5b642BE32C3c874613", "quantity": 1, "done": true},
+  {"wallet": "0x06Df3F02E84F7034CF70f52cdf5Cdc0Ab02F6Fea", "quantity": 1, "done": true},
+  {"wallet": "0xb6314005148f51d6B1340B7f021DB8679bd85596", "quantity": 1, "done": true},
+  {"wallet": "0xC9DC2b2C152229f953FDcc65F157dfce38cd2475", "quantity": 1, "done": true},
+  {"wallet": "0xbBFC75D703e19a1222F80Eb943a56752b5cf38bf", "quantity": 1, "done": true},
+  {"wallet": "0x021D3D3a143c84256ce8e00db8813f7E8d6d56EB", "quantity": 1, "done": true},
+  {"wallet": "0x8ccB4FeE9938B91D3f723D66e71948ee08cdD0cD", "quantity": 1, "done": true},
+  {"wallet": "0x6c877fFf366532D828018e77498AaAAd71464724", "quantity": 1, "done": true},
+  {"wallet": "0x32B89dEa9Dfbcf19760CbeA6eB52261C6c2642EC", "quantity": 1, "done": true},
+  {"wallet": "0x2beed6BbE9B466477C495e24cfD0302C7eC7a00e", "quantity": 1, "done": true},
+  {"wallet": "0xAe250038133696ACCcBf24B28D04DCdd9090D256", "quantity": 1, "done": true},
+  {"wallet": "0xE131b551994f56d1CCa7bDaaa18E94Fbf80cef7E", "quantity": 1, "done": true},
+  {"wallet": "0x95425e5abb5CEce0C5653DD77bE02b7913e53488", "quantity": 1, "done": true},
+  {"wallet": "0xedCD8F695eEf2BFBDa6b60d7BB520150FaAdc4B8", "quantity": 1, "done": true},
+  {"wallet": "0x7ab1475ab635B6b28cb705B58B77CBFcb9f2B4ec", "quantity": 1, "done": true},
+  {"wallet": "0x7080320bED0ca0d46585aA8A81bA66880650B720", "quantity": 1, "done": true},
+  {"wallet": "0xE147f089D6232d34d25659A2e41Eb2B5C52aE643", "quantity": 1, "done": true},
+  {"wallet": "0x7cA4c6dD8e8754e9A767D21e0542549dA58dd374", "quantity": 1, "done": true},
+  {"wallet": "0x5AcBD3b267d1D5e95E26ED97C1856c6Bb4BE8f28", "quantity": 1, "done": true},
+  {"wallet": "0xE162c3558d67c79C039Db752F0efE0C0E13cFf5F", "quantity": 1, "done": true},
+  {"wallet": "0xcaAA82aE25A696CDc7fA4da3240084f3Ceb83F4b", "quantity": 1, "done": true},
+  {"wallet": "0x49E6E064101034e0E67f43f80F52Fee8c3a1d761", "quantity": 1, "done": true},
+  {"wallet": "0xe28d7E87b0dBda55B5560CB2fc3409CD7d4631DD", "quantity": 1, "done": true},
+  {"wallet": "0x41868152a143ECeAF87C05D8ae86FDc8Cb38De68", "quantity": 1, "done": true},
+  {"wallet": "0x11bD7ec08f4eadAbb7E74001D399F15CacFc99b6", "quantity": 1, "done": true},
+  {"wallet": "0xf0deDE477E1F4283C8Bd47d8D7E21Ee7C7922E12", "quantity": 1, "done": true},
+  {"wallet": "0x7948cE471b0838F00BC9926b4625075fd702Be63", "quantity": 1, "done": true},
+  {"wallet": "0xaaB86239606e1755abDe3C0cCe833340b2A88c72", "quantity": 1, "done": true},
+  {"wallet": "0x4088d02D9198FC9471f37ce1789E2c6c9658A9ce", "quantity": 1, "done": true},
+  {"wallet": "0xf4c7db023BF4A3046C6b8fF10D40e8f7C0223c97", "quantity": 1, "done": true},
+  {"wallet": "0x750D8C84cE9FD52677e49710b93057F0fD6f29Cd", "quantity": 1, "done": true},
+  {"wallet": "0x3bAa2ABf45A8146EeA9Da9C4B0D1a58f22238525", "quantity": 1, "done": true},
+  {"wallet": "0xaB6Bb077306a3e905E84329996902e0C7ef4a721", "quantity": 1, "done": true},
+  {"wallet": "0x5a33cE0e4B32e592728DC10FD4C2E20d13A8F5dF", "quantity": 1, "done": true},
+  {"wallet": "0xdC8EEB01df612a0cCc74E8eed362129bC2186C8a", "quantity": 1, "done": true},
+  {"wallet": "0x21b43179E68cD635Cf5fb19538B97C5648dBf685", "quantity": 1, "done": true},
+  {"wallet": "0xDc4A381246357db903B6c53D1a9A9dd4fE878271", "quantity": 1, "done": true},
+  {"wallet": "0xbE95f030Fe39bdb9Ff8fC249Ac253785557060bd", "quantity": 1, "done": true},
+  {"wallet": "0x521E6B622a198B91Ac27CD44Fd2264E48b3cF41D", "quantity": 1, "done": true},
+  {"wallet": "0xC261924c9EB7b02EFC14027B707b7F2daf890D27", "quantity": 1, "done": true},
+  {"wallet": "0xcDd4afF32c042F33867294BE96e7013E69a34e0B", "quantity": 1, "done": true},
+  {"wallet": "0x8F564a2D058171a20CbFBd48EFEe785c77F4Cea9", "quantity": 1, "done": true},
+  {"wallet": "0x0e5222F40A40E3603895B55c54a93EDD2Da24529", "quantity": 1, "done": true},
+  {"wallet": "0xdDD8cbdBF508a7aaE565026D607097A282916362", "quantity": 1, "done": true},
+  {"wallet": "0xe2443169f25b4a4DEE3A29F7326c1dDCeaFFCA63", "quantity": 1, "done": true},
+  {"wallet": "0x05d03d54772eF6420C56a680A5F5b3DEab6F5997", "quantity": 1, "done": true},
+  {"wallet": "0x78eE7327457EDFa8A1D9f067db64E755EAeEDe6E", "quantity": 1, "done": true},
+  {"wallet": "0x381712d37b333164aEe06f26293a45339359c140", "quantity": 1, "done": true},
+  {"wallet": "0xFF997fA97519563738705B72fFB97Da25601e604", "quantity": 1, "done": true},
+  {"wallet": "0x116f1787058A4c9e5c8A8Bd6E4D311EF3C99afDD", "quantity": 1, "done": true},
+  {"wallet": "0x1cdA720e9E10510D6214CB83a72a9A608b558C86", "quantity": 1, "done": true},
+  {"wallet": "0xc17A878D9c03B8191275F85fd8f4dfb76137D807", "quantity": 1, "done": true},
+  {"wallet": "0xB5C6d75678927DdF54B2ea25B87bA5f3588B23cC", "quantity": 1, "done": true},
+  {"wallet": "0x26eF425B91Cc50168Ce65349CB6d35AAb4f1d912", "quantity": 1, "done": true},
+  {"wallet": "0x318F66a11f2eC1c1B9Dbe8EB4CdCaC59Bf1a75CC", "quantity": 1, "done": true},
+  {"wallet": "0x1DA4400316275C34f7d4Ff5448afA461AB386650", "quantity": 1, "done": true}
 ]

--- a/scripts/data/freeFarmWinners.json
+++ b/scripts/data/freeFarmWinners.json
@@ -1,0 +1,866 @@
+[
+  {
+    "wallet": "0x3487bA6A9c9FEA8AfAb35ebdF48B3A27532B7915",
+    "quantity": 14
+  },
+  {
+    "wallet": "0x88FeaD4cBc338F54C6a1517303cf79B3a03D7A2b",
+    "quantity": 8
+  },
+  {
+    "wallet": "0xF153BA46b70363A887ed7cddf87fbcbf2005D621",
+    "quantity": 6
+  },
+  {
+    "wallet": "0x4eF6511BbbEcB6a0F663638cF22381364763FD71",
+    "quantity": 5
+  },
+  {
+    "wallet": "0xbd101FFfAC618cc704F005315143dd63b445C5E7",
+    "quantity": 4
+  },
+  {
+    "wallet": "0xAC8869fcFBdEd40cb65450Abd4DB1A9e380aC7DD",
+    "quantity": 3
+  },
+  {
+    "wallet": "0x1f15d72245348cf28d060e5BE2eD25a948B2f222",
+    "quantity": 3
+  },
+  {
+    "wallet": "0xC485EE59d1D69f44d87c0545Ca1c641E05d04a76",
+    "quantity": 3
+  },
+  {
+    "wallet": "0x079f0F0423b181EedC71e9b2eD6b15B1d957c5Ac",
+    "quantity": 3
+  },
+  {
+    "wallet": "0x29895a3092Cbe1dBb7f2e65358978747341dbf01",
+    "quantity": 3
+  },
+  {
+    "wallet": "0xE8C836220F0E7f75DE25108027fBf65559DEd97E",
+    "quantity": 3
+  },
+  {
+    "wallet": "0x1e00B459fbdD319ea26e8D764ffd3c968C9d2E34",
+    "quantity": 3
+  },
+  {
+    "wallet": "0x0cd24d1537568f82237AC7d076D9418dc06b79d6",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xfaCAA385E2E81623C8cADA6d847aBf0814624b52",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xbB7DDaB6fD9B3A3c5f959cf2F7dB69acbe54c184",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xDa1EC4dA97019972759FedA1285878b97FDCC014",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x928c7D940ceCEd2f9AC6bAba5f582B18Ec1C7aBF",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x2d51caB9CE3dBACDA14aa65C5236D73b583bd156",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x8ee08C2ABB76488793b3204E75a4FAecd611E59F",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xbc8E4C006Bd1B96C1a50E8727F0b10874e6b261E",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x3aBcB5d5FB4044620c319bB63c5540a04e024AA1",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x2B08254f95422d7FdBfDE173E453e1F7e31C405B",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x18e3398cAd87b063817B45D21684aF908e207468",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x233A515c1c3Af772509fB14cCa5F37072aa2a070",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xDCF723610fdeB412A9Fe17AE9C2df98c2CbCA10F",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xd341db5BB6176bEDB6c3e62Aa5CC07088325b7aF",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xeEF94beD5a0C474794DB4bd2f28f3fe705cDEae4",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xb91bBdE050F65b0334aaD44ff05898F30daa3875",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x38cA36df97De1a5663342B832481D94355ac9D27",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x9B2b533Bc29e7555DF042C58415495812D95048b",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xf65d2EFc1fDA19847Fd82a48A122B73f0e3B84D0",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xf28BdE07be3517618913438F4f4448Aba4A816D9",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xF89d3C2D33835992b48F37205E32EA68c7680dF4",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x7fDbdc0C1035EdA3C53F14EEb5bc4C5C0997B9c1",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x0A2809076b654D6951E41b03568F16717a50Af4A",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x94bd3400e28a715e8C078117B61Ecf678139a294",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x833186a107A881e7A39DA9D88999f55dc7350CBe",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x2829DFDC378C507c3B2D80EF5f99B1F199573FF3",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x277B457fcCd42b7d1ab0e67d79b49ddf749546a6",
+    "quantity": 2
+  },
+  {
+    "wallet": "0x59FC43183C6b3E874d9F7eeaF79A0F708A8Cc08D",
+    "quantity": 2
+  },
+  {
+    "wallet": "0xd04111Fc8F4e432CF41166Bacb88994F7cbF3ff5",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x9cc5EA498eA8466b9BC6bBff1775B81Bbe1E6719",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xeCeCd4f560161e0A12C8673DE3073aAEB3c47e1D",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xcEC87a49Fec7aA9e2A4AB8Db6C1C5056f3511249",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xae77f2A6D9E52db6a9761F13200093868aE06255",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xCa27f3B574d9AeA4123cCC397ce4110b48CD1521",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x2d98E26d0C4555C6Ca8BeA476134E5B899b6838d",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xc0Cf3f7ab953fE6ad5d90E4396601DA6F5C3c35b",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xA3b0347C211aCD972891803a49Ab28D632Eabf75",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xA60A3b210e9776B223e14B51C4285e034715C9b2",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x131cD5E746Fa428C80b34A70b136C36722C613ae",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x9f85969E627B8E6CEA07AF65ea2DFFCacFd76556",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xB981290d9d804075986482F0302c03A3Cd2aFf32",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x84bA38696f4F2dbCb88Ec2C5F82d24A074d2E6fe",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xeacb9f0d1C8186eb2aCa48a89Ee01ff6De3bc28a",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xdC9C1e1d7d8AB77aA0090fB981a811f3E5127484",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xfa98bCb727c284897f4fD75BEabC9201011D0e93",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf030FEe72b6dCA0367ceBb133d6E751Ae27d6a76",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xc42adD8541a7111bb53D1d0C7f379a0d981c9a98",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x78Ffa27D122043874DBE879B7173180FeD3ccf1D",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1fEAb880bB6E81761920C7314BF1789d3325Cd33",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xBcC13DdAc2a722afD9348ccfD31fdC95F79a6277",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x529051F57Fa91c60044d4C523A4A24B058b8278A",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x98C7e670D808E02a2fd4099ADc52987c2f43d1aA",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xB78AB8c7268EC59DD324a2E3BA6A359c20a54D46",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x6B3FE9b09B65AD7235AC8265B3B51699F2813e9C",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1db36587e47a48D9534D5a4a5dBB6d10C8726db9",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x81e3C9dED64CAF37ee5fFd643637E1a97CD64F5f",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xBAfD1aF4F0CEa198396d5a3087219497Ff7dcaB0",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x9b136F12d78f68b078d80e242606422c64Ada80C",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xD4852b7419F58793EbBE66F2c1382a10c8f6A9FF",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x15938984172df4ee65582c697316B08a5e6de452",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x8Ed1bdB5bd669Be2121c48A6D178CAB35BCb43d0",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x97e142399C4CbA7B4d36b40aa767F9643B34978d",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xA697765F211951c6dA378Dae4D69BA0a39881bFb",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x4D1750f3aB3e746538F302b9dEd3Db31317B64A7",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xae74f7B79D3e32A819675403e54A550824C0bF02",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x348AaC0a9935277784f9fF6fACBe4B202f02e6a1",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x9065BEE921567772854C38b826a794349f5eE2B5",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7764F37E255B12B02e6936B7a060ea73EC45B431",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x50e560e7cB99e321c110EEE560a2Da8364a290F9",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x4c9C3626Cf1828Da7b58a50DC2F6AA2C4546609e",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x4f73E33721eDc1EcAe5A45261fBe6C0bC4Fb1685",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x6a74DF3e3B2BBC7D1BC4ceF29543fc41C86c452e",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf628cE0687d35089FBef40aD3680356E7B638863",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x86E4F4AE2e09bcEc1dFDeeAa7c378821e56b7b3e",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xb299D1c0904691B3EBCB337293bd5eD657036eC1",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xB885Cb7070A084A4Ae2de3F8507927fc213998DF",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xF22Ea607A889EB21451e3f52C9D191da49Dd8836",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5b0d1192cCf825DB63D9371d4380f880898e3354",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xC2978441F46a76c60e0cd59E986498b75a40572D",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1A5A74DF8E578CaFc56c99C655fB8eAF6692Be6e",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x59c33EF5CF07e2b7df5d8Ac8Ee931F0E39047A23",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xeEa1DF0EF4E90154fC893503c5F05c30bBD4e885",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xAEFB17544Eebfd18e2F5FdFDa43B5Be69Baf8246",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x98FD7670F441E3de7f071C0aCFb1Fd567998C8d2",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x07e7CBa9F29c7732F1c87e018fEBbD13E2f264A5",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x96DE627bE6262aD2E19553824aAD1aF6Ba1eBe9B",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xa2225b86CCB530ac9a81D41a3d17ab643A9f7c8C",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xb1e5B583780d2D97B0E75F3C58dc0751444871f1",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xd9eeb6ac27c3A5eE37F967EEFBd5D7A33bE5ebD2",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1E545bbb0cC33163fED5339f7a72167B53EdA13a",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x73E9411A0e782b62887c6A3423aDFAFd747301a8",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x253a41571830Dca332724DFF29Afb8960ffcCDf6",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xF6C9692A490BAf4b4dfa9BD1c9fc4438c38b5321",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x777d92Fcb83Ca9131B05ce579D9A951019c4Ca5c",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x71039d40ad2123b23FDFfe56453E903a515E5ac5",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x38671F9A37bD37EA52aD63182D3Ff6a64e2692D6",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x8Fc87c199203332c1cc43430b9FaD2B1868E44D0",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3F6D62DA04f6B3F3fc0dDeFeB17543fAc278e383",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xF79765D064B86648C7C01F55f9eCB5ec5D3A7d4b",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1fDbFfD0d8e237E64E68A904c2a6F447a1aD5C90",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x6707b67dA257d77DDAe75D24476436e608E45c09",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xe481BD03D8fAF78cc18bDD0118073007EED82f67",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3De6A9B46E4840F5D235626CF07fE48a7e044fB0",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x2EFEEb8D5Df533565a44F1A1ACf12Cd5B46196CF",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3dC7F8850CbfE558eeE8442d553fdE8eb49DcF5D",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xa728ba7C90AFC95423aA00bb9bbcBe68fd80be5d",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf5Fc69ECd8DdaAba72B73830b02592200bB78918",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5d73eEe7E0d8C955F9d442B12d463B4c5B8e7dC3",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x77Ed421D98BF2fe6542Ae6EEeD341B759C6E764a",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xe1645f135525ba04C90235718b4C33c995253e16",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x4Ed78BC2FCFF4441dAb71fc8aAB65FF94D18dB15",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf02aaeA623E7C0AC779D68d734BEd438e67775Eb",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x245Ca790317489C2252F63b95Dab698C7955a9A3",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xDCC9F7368EE6636FC2f7A02b713072D75474D9E6",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf1439E1D1EfB1a90983a6Ae306cE42B6921e093b",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5C4e877b3f410d4c505be0D8D3d77cC34cEae548",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7BC6230B10824e28c57aE71fC98d80A4988F11a6",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x78834B429d868108d8f9b4dB9B0348EF2BC23257",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5D20e6c0DB887B5c3281EdfCe5BB7677565e2B8f",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xA6A88909c58640deBDf86FdC7179A25e036378b3",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xC4f2C31F364423c3BFfd766c9B320f5eC64da64e",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x43Ec5640E18F7384761d8817AA55d38C9a03D855",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xeFfeC91cF9CEd27dF6dD9eBC9D465E5D14db2618",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3164ed5B9D37Ac9619aC5895CA33F308aB02a053",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x310115b783a94C6Fc371Ed03eB7d3fe15b1D02e2",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x8F42E67db71a3542E4398b138C5CE8Aaad694aD6",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xD5c69ecCc7d8e0c124c205328cC6CEC584b4E15A",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7aDBee9c890eb294A816a0aAc5507cc1DEF53598",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xcAC3dce2CaB052B903dA719F99Ed182bf7A22fDb",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1c16BE3c5D62842D950eFA6675214aEca45ABb1f",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3d78BDB36f63aFA32973bF19F5c689bEA9627F03",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x9c709C02b87072C8599c5416617FD259D334EEf2",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1643635228eda7c2c82F05B520FE755EabAed547",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x935002727A6EBBcaf01a0039DB0e6B1f9C175f0b",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x556501B3A439f105f14ddeb5D96a892f9E3502CC",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3500e121e102C88cE7cb92dd4A8B074CCF704560",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1e57EBeA7b301877B925551dB9c2eB2917537681",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xd853eb73b3657CbCD32438289F2C89A4b487FDda",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5b49F719262FFf473628E2223971a0Ba2cafa62a",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x502a4beC9AEb8Afa10408FcCb89361FB206DaB78",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x682955aC3cc48433060e40200E214Bdca6b40Dd4",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xC7DcfC4873f4DA211da8C255c9F1d2B18713845F",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xd88DFEa2ddB0d73C23A3710bCb572fe58589eC76",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xac905fd0B601bEb21E1cDDc9d6Aea64Bebce855a",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x750554C8CD238765FCDe9467E33E6e6d595265F2",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x0351788F4e05FF3C40F601B5FA6ba4B6E44633E5",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x033f29B41D74E548967B9eA9bAa004DA704161fb",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xC1Eab99C6F2cd06ad1C60e5b642BE32C3c874613",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x06Df3F02E84F7034CF70f52cdf5Cdc0Ab02F6Fea",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xb6314005148f51d6B1340B7f021DB8679bd85596",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xC9DC2b2C152229f953FDcc65F157dfce38cd2475",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xbBFC75D703e19a1222F80Eb943a56752b5cf38bf",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x021D3D3a143c84256ce8e00db8813f7E8d6d56EB",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x8ccB4FeE9938B91D3f723D66e71948ee08cdD0cD",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x6c877fFf366532D828018e77498AaAAd71464724",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x32B89dEa9Dfbcf19760CbeA6eB52261C6c2642EC",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x2beed6BbE9B466477C495e24cfD0302C7eC7a00e",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xAe250038133696ACCcBf24B28D04DCdd9090D256",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xE131b551994f56d1CCa7bDaaa18E94Fbf80cef7E",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x95425e5abb5CEce0C5653DD77bE02b7913e53488",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xedCD8F695eEf2BFBDa6b60d7BB520150FaAdc4B8",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7ab1475ab635B6b28cb705B58B77CBFcb9f2B4ec",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7080320bED0ca0d46585aA8A81bA66880650B720",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xE147f089D6232d34d25659A2e41Eb2B5C52aE643",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7cA4c6dD8e8754e9A767D21e0542549dA58dd374",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5AcBD3b267d1D5e95E26ED97C1856c6Bb4BE8f28",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xE162c3558d67c79C039Db752F0efE0C0E13cFf5F",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xcaAA82aE25A696CDc7fA4da3240084f3Ceb83F4b",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x49E6E064101034e0E67f43f80F52Fee8c3a1d761",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xe28d7E87b0dBda55B5560CB2fc3409CD7d4631DD",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x41868152a143ECeAF87C05D8ae86FDc8Cb38De68",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x11bD7ec08f4eadAbb7E74001D399F15CacFc99b6",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf0deDE477E1F4283C8Bd47d8D7E21Ee7C7922E12",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x7948cE471b0838F00BC9926b4625075fd702Be63",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xaaB86239606e1755abDe3C0cCe833340b2A88c72",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x4088d02D9198FC9471f37ce1789E2c6c9658A9ce",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xf4c7db023BF4A3046C6b8fF10D40e8f7C0223c97",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x750D8C84cE9FD52677e49710b93057F0fD6f29Cd",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x3bAa2ABf45A8146EeA9Da9C4B0D1a58f22238525",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xaB6Bb077306a3e905E84329996902e0C7ef4a721",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x5a33cE0e4B32e592728DC10FD4C2E20d13A8F5dF",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xdC8EEB01df612a0cCc74E8eed362129bC2186C8a",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x21b43179E68cD635Cf5fb19538B97C5648dBf685",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xDc4A381246357db903B6c53D1a9A9dd4fE878271",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xbE95f030Fe39bdb9Ff8fC249Ac253785557060bd",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x521E6B622a198B91Ac27CD44Fd2264E48b3cF41D",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xC261924c9EB7b02EFC14027B707b7F2daf890D27",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xcDd4afF32c042F33867294BE96e7013E69a34e0B",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x8F564a2D058171a20CbFBd48EFEe785c77F4Cea9",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x0e5222F40A40E3603895B55c54a93EDD2Da24529",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xdDD8cbdBF508a7aaE565026D607097A282916362",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xe2443169f25b4a4DEE3A29F7326c1dDCeaFFCA63",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x05d03d54772eF6420C56a680A5F5b3DEab6F5997",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x78eE7327457EDFa8A1D9f067db64E755EAeEDe6E",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x381712d37b333164aEe06f26293a45339359c140",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xFF997fA97519563738705B72fFB97Da25601e604",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x116f1787058A4c9e5c8A8Bd6E4D311EF3C99afDD",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1cdA720e9E10510D6214CB83a72a9A608b558C86",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xc17A878D9c03B8191275F85fd8f4dfb76137D807",
+    "quantity": 1
+  },
+  {
+    "wallet": "0xB5C6d75678927DdF54B2ea25B87bA5f3588B23cC",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x26eF425B91Cc50168Ce65349CB6d35AAb4f1d912",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x318F66a11f2eC1c1B9Dbe8EB4CdCaC59Bf1a75CC",
+    "quantity": 1
+  },
+  {
+    "wallet": "0x1DA4400316275C34f7d4Ff5448afA461AB386650",
+    "quantity": 1
+  }
+]

--- a/scripts/deploy-airdrop-farms.js
+++ b/scripts/deploy-airdrop-farms.js
@@ -1,0 +1,53 @@
+require("dotenv").config();
+const path = require("path");
+const fs = require("fs-extra");
+const hre = require("hardhat");
+const ethers = hre.ethers;
+const {getCurrentTimestamp} = require("hardhat/internal/hardhat-network/provider/utils/getCurrentTimestamp");
+const farmWinners = require("./data/freeFarmWinners.json");
+
+const DeployUtils = require("./lib/DeployUtils");
+
+async function main() {
+  let deployUtils = new DeployUtils(ethers);
+  // require("./consoleLogAlert")();
+
+  const chainId = await deployUtils.currentChainId();
+  let [deployer] = await ethers.getSigners();
+
+  const network = chainId === 56 ? "bsc" : chainId === 44787 ? "alfajores" : chainId === 43113 ? "fuji" : "localhost";
+
+  console.log("Deploying contracts with the account:", deployer.address, "to", network);
+
+  console.log("Account balance:", (await deployer.getBalance()).toString());
+
+  const farm = await deployUtils.attach("Farm");
+  const factory = await deployUtils.attach("NftFactory");
+
+  if (await farm.hasFactories()) {
+    await farm.setFactory(factory.address, false);
+  }
+
+  for (let i = farmWinners.length - 1; i >= 0; i--) {
+    const {wallet, quantity, done} = farmWinners[i];
+    if (chainId !== 56 || !done) {
+      await deployUtils.Tx(
+        farm.mint(wallet, quantity, {
+          gasLimit: 100000 + 130000 * quantity,
+        }),
+        "Minting " + quantity + " free farms to " + wallet
+      );
+      if (chainId === 56) {
+        farmWinners[i].done = true;
+        await fs.writeFile(path.resolve(__dirname, "data/freeFarmWinners.json"), JSON.stringify(farmWinners));
+      }
+    }
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/deploy-airdropwl.js
+++ b/scripts/deploy-airdropwl.js
@@ -80,8 +80,10 @@ async function main() {
     }
   }
 
-  await airdrop(turfWl, 1);
-  await airdrop(farmWl, 2);
+  await wl.mintBatch("0xA32912c58298f49a99B9eA3084721056F5d22FF1", [1, 2], [4, 4]);
+
+  // await airdrop(turfWl, 1);
+  // await airdrop(farmWl, 2);
 }
 
 main()

--- a/scripts/deploy-sale.js
+++ b/scripts/deploy-sale.js
@@ -47,9 +47,12 @@ async function main() {
 
   await deployUtils.Tx(factory.setWl(wl.address), "Set WL in factory");
 
-  const startDate = new Date("2022-12-15T17:30:00.000Z");
-  const startAt = parseInt(startDate.getTime() / 1000);
-  const wlEndAt = startAt + 3600 * 24 * 4;
+  let startDate = new Date("2022-12-15T17:30:00.000Z");
+  if (chainId !== 56) {
+    startDate = new Date();
+  }
+  const startAt = parseInt(startDate.getTime() / 1000) + 60;
+  const wlEndAt = startAt + 3600 * 24;
 
   await deployUtils.Tx(
     factory.newSale(1, 135, startAt, wlEndAt, 1, [busd.address, seed.address], [pe(420), pe(220500)], [pe(599), pe(295000)]),

--- a/scripts/lib/DeployUtils.js
+++ b/scripts/lib/DeployUtils.js
@@ -2,8 +2,6 @@ const path = require("path");
 const fs = require("fs-extra");
 const {Contract} = require("@ethersproject/contracts");
 const abi = require("ethereumjs-abi");
-const {deployProxyImpl} = require("@openzeppelin/hardhat-upgrades/dist/utils");
-
 let deployedJson = require("../../export/deployed.json");
 
 const oZChainName = {
@@ -178,12 +176,12 @@ class DeployUtils {
 
       const deployedFilename = process.env.NODE_ENV === "test" ? "deployedForTest" : "deployed";
 
-      const deployedJson = path.resolve(__dirname, `../../export/${deployedFilename}.json`);
-      if (!(await fs.pathExists(deployedJson))) {
-        await fs.ensureDir(path.dirname(deployedJson));
-        await fs.writeFile(deployedJson, "{}");
+      const deployedJsonPath = path.resolve(__dirname, `../../export/${deployedFilename}.json`);
+      if (!(await fs.pathExists(deployedJsonPath))) {
+        await fs.ensureDir(path.dirname(deployedJsonPath));
+        await fs.writeFile(deployedJsonPath, "{}");
       }
-      const deployed = JSON.parse(await fs.readFile(deployedJson, "utf8"));
+      const deployed = JSON.parse(await fs.readFile(deployedJsonPath, "utf8"));
       if (!deployed[chainId]) {
         deployed[chainId] = {};
       }
@@ -204,7 +202,7 @@ class DeployUtils {
         deployed.extras[chainId] = Object.assign(deployed.extras[chainId], extras);
       }
       // console.log(deployed)
-      await fs.writeFile(deployedJson, JSON.stringify(deployed, null, 2));
+      await fs.writeFile(deployedJsonPath, JSON.stringify(deployed, null, 2));
     }
   }
 

--- a/test/NftFactory.test.js
+++ b/test/NftFactory.test.js
@@ -278,4 +278,25 @@ describe("NftFactory", function () {
       );
     });
   });
+
+  describe.only("Airdrop if no factory", async function () {
+    beforeEach(async function () {
+      await initAndDeploy(true);
+    });
+
+    it("should work if no factory is set up", async function () {
+      await farm.setFactory(factory.address, false);
+      await expect(farm.mint(beneficiary.address, 3))
+        .to.emit(farm, "Transfer")
+        .withArgs(ethers.constants.AddressZero, beneficiary.address, 1)
+        .to.emit(farm, "Transfer")
+        .withArgs(ethers.constants.AddressZero, beneficiary.address, 2)
+        .to.emit(farm, "Transfer")
+        .withArgs(ethers.constants.AddressZero, beneficiary.address, 3);
+    });
+
+    it("should fail if at least one factory is set up", async function () {
+      await expect(farm.mint(beneficiary.address, 4)).revertedWith("Forbidden()");
+    });
+  });
 });

--- a/test/NftFactory.test.js
+++ b/test/NftFactory.test.js
@@ -302,5 +302,13 @@ describe("NftFactory", function () {
     it("should fail if at least one factory is set up", async function () {
       await expect(farm.mint(beneficiary.address, 4)).revertedWith("Forbidden()");
     });
+
+    it("should unset and set again a factory", async function () {
+      await expect(farm.mint(beneficiary.address, 4)).revertedWith("Forbidden()");
+      await farm.setFactory(factory.address, false);
+      await expect(farm.mint(beneficiary.address, 1)).to.emit(farm, "Transfer").withArgs(AddressZero, beneficiary.address, 1);
+      await farm.setFactory(factory.address, true);
+      await expect(farm.mint(beneficiary.address, 1)).revertedWith("Forbidden()");
+    });
   });
 });

--- a/test/NftFactory.test.js
+++ b/test/NftFactory.test.js
@@ -14,6 +14,8 @@ describe("NftFactory", function () {
   let seed, busd;
   let startsAt, endsAt;
 
+  const {AddressZero} = ethers.constants;
+
   const deployUtils = new DeployUtils(ethers);
 
   function pe(amount) {
@@ -41,7 +43,7 @@ describe("NftFactory", function () {
     await farm.deployed();
     await farm.setMaxSupply(5000);
 
-    await farm.mint(owner.address, 3);
+    // await farm.mint(owner.address, 3);
 
     busd = await deployUtils.deployProxy("SeedTokenMock");
     await busd.deployed();
@@ -131,11 +133,11 @@ describe("NftFactory", function () {
 
       expect(await factory.connect(whitelisted).buyTokens(1, busd.address, 3))
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, whitelisted.address, 1)
+        .withArgs(AddressZero, whitelisted.address, 1)
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, whitelisted.address, 2)
+        .withArgs(AddressZero, whitelisted.address, 2)
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, whitelisted.address, 3);
+        .withArgs(AddressZero, whitelisted.address, 3);
 
       expect(await turf.nextTokenId()).equal(4);
       expect(await wl.balanceOf(whitelisted.address, 1)).equal(2);
@@ -164,11 +166,11 @@ describe("NftFactory", function () {
 
       expect(await factory.connect(whitelisted).buyTokens(1, seed.address, 3))
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, whitelisted.address, 1)
+        .withArgs(AddressZero, whitelisted.address, 1)
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, whitelisted.address, 2)
+        .withArgs(AddressZero, whitelisted.address, 2)
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, whitelisted.address, 3);
+        .withArgs(AddressZero, whitelisted.address, 3);
 
       expect(await turf.nextTokenId()).equal(4);
       expect(await wl.balanceOf(whitelisted.address, 1)).equal(2);
@@ -243,13 +245,13 @@ describe("NftFactory", function () {
 
       await expect(factory.connect(notWhitelisted).buyTokens(1, busd.address, 1))
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, notWhitelisted.address, 1);
+        .withArgs(AddressZero, notWhitelisted.address, 1);
       await expect(factory.connect(notWhitelisted).buyTokens(1, busd.address, 1))
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, notWhitelisted.address, 2);
+        .withArgs(AddressZero, notWhitelisted.address, 2);
       await expect(factory.connect(notWhitelisted).buyTokens(1, busd.address, 1))
         .to.emit(turf, "Transfer")
-        .withArgs(ethers.constants.AddressZero, notWhitelisted.address, 3);
+        .withArgs(AddressZero, notWhitelisted.address, 3);
       expect(await turf.nextTokenId()).equal(4);
     });
   });
@@ -279,20 +281,22 @@ describe("NftFactory", function () {
     });
   });
 
-  describe.only("Airdrop if no factory", async function () {
+  describe("Airdrop if no factory", async function () {
     beforeEach(async function () {
       await initAndDeploy(true);
     });
 
     it("should work if no factory is set up", async function () {
+      expect(await farm.hasFactories()).equal(true);
       await farm.setFactory(factory.address, false);
+      expect(await farm.hasFactories()).equal(false);
       await expect(farm.mint(beneficiary.address, 3))
         .to.emit(farm, "Transfer")
-        .withArgs(ethers.constants.AddressZero, beneficiary.address, 1)
+        .withArgs(AddressZero, beneficiary.address, 1)
         .to.emit(farm, "Transfer")
-        .withArgs(ethers.constants.AddressZero, beneficiary.address, 2)
+        .withArgs(AddressZero, beneficiary.address, 2)
         .to.emit(farm, "Transfer")
-        .withArgs(ethers.constants.AddressZero, beneficiary.address, 3);
+        .withArgs(AddressZero, beneficiary.address, 3);
     });
 
     it("should fail if at least one factory is set up", async function () {


### PR DESCRIPTION
Updating the dependencies to support IERC5192. It requires a contract upgrade.
We integrated https://github.com/ndujaLabs/erc721lockable in our contracts. 
The v0.3.0 of the reference implementation introduces a breaking change with the 0.2.0 in order to support IERC5192 (which is in the final stage of approve process).