### PR TITLE
Add comment to wl

### DIFF
--- a/contracts/WhitelistSlot.sol
+++ b/contracts/WhitelistSlot.sol
@@ -46,6 +46,10 @@ contract WhitelistSlot is ERC1155, Ownable {
     uint256[][] memory amounts
   ) public onlyOwner {
     if (to.length != ids.length || ids.length != amounts.length) revert InconsistentArrays();
+    // NOTE
+    // This is in theory risky because the contract can go out of cash. In reality it is a
+    // calculated risk because this function is called by a script that manages the airdrop
+    // of the tokens and takes care of the gas cost and the number of tokens that can be safely minted.
     for (uint256 i = 0; i < ids.length; i++) {
       _mintBatch(to[i], ids[i], amounts[i], "");
     }


### PR DESCRIPTION
Adding a comment to WhitelistSlot to explain why using a loop in that function is not a real risk. Actually, that convenient function has been successfully used by an airdrop script that took care of the gas consumption to avoid going out of gas.