### PR TITLE
Make the token owner unlock its own token if the locker is disabled

### DIFF
--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -277,12 +277,15 @@ abstract contract SuperpowerNFTBase is
   }
 
   // emergency function in case a compromised locker is removed
-  function unlockIfRemovedLocker(uint256 tokenId) external override onlyOwner {
+  function unlockIfRemovedLocker(uint256 tokenId) external override {
     if (!locked(tokenId)) {
       revert NotLockedAsset();
     }
     if (_lockers[_lockedBy[tokenId]]) {
       revert NotADeactivatedLocker();
+    }
+    if (ownerOf(tokenId) != _msgSender()) {
+      revert NotTheAssetOwner();
     }
     delete _lockedBy[tokenId];
     emit ForcefullyUnlocked(tokenId);


### PR DESCRIPTION
The function unlockIfRemovedLocker can be called if a locker is disable for any reason and some token remains locked after that. Initially, the idea was that the contract owner could unlock them, but a more flexible approach is to allow the token owner to unlock them.