### PR TITLE
Make easier to rotate validators

### DIFF
--- a/contracts/GamePool.sol
+++ b/contracts/GamePool.sol
@@ -135,9 +135,9 @@ contract GamePool is IGamePool, SignableStakes, Constants, UUPSUpgradableTemplat
     bytes calldata signature1
   ) external override {
     if (tokenType != TURF && tokenType != FARM) revert invalidTokenType();
-    if (!isSignedByValidator(0, hashUnstake(tokenType, tokenId, stakeIndex, randomNonce), signature0))
+    if (!isSignedByAValidator(0, 2, hashUnstake(tokenType, tokenId, stakeIndex, randomNonce), signature0))
       revert invalidPrimarySignature();
-    if (!isSignedByValidator(1, hashUnstake(tokenType, tokenId, stakeIndex, randomNonce), signature1))
+    if (!isSignedByAValidator(1, 3, hashUnstake(tokenType, tokenId, stakeIndex, randomNonce), signature1))
       revert invalidSecondarySignature();
     _saveSignatureAsUsed(signature0);
     _saveSignatureAsUsed(signature1);
@@ -255,7 +255,7 @@ contract GamePool is IGamePool, SignableStakes, Constants, UUPSUpgradableTemplat
     uint256 randomNonce,
     bytes calldata signature0
   ) external override {
-    if (!isSignedByValidator(0, hashDeposit(_msgSender(), amount, depositId, randomNonce), signature0))
+    if (!isSignedByAValidator(0, 2, hashDeposit(_msgSender(), amount, depositId, randomNonce), signature0))
       revert invalidPrimarySignature();
     _saveSignatureAsUsed(signature0);
     _depositFT(SEED, amount, depositId, _msgSender());
@@ -272,7 +272,7 @@ contract GamePool is IGamePool, SignableStakes, Constants, UUPSUpgradableTemplat
     uint256 randomNonce,
     bytes calldata signature0
   ) external override {
-    if (!isSignedByValidator(0, hashDeposit(_msgSender(), amount, depositId, randomNonce), signature0))
+    if (!isSignedByAValidator(0, 2, hashDeposit(_msgSender(), amount, depositId, randomNonce), signature0))
       revert invalidPrimarySignature();
     _saveSignatureAsUsed(signature0);
     _depositFT(BUD, amount, depositId, _msgSender());
@@ -393,9 +393,9 @@ contract GamePool is IGamePool, SignableStakes, Constants, UUPSUpgradableTemplat
     bytes calldata signature1
   ) external override {
     if (deadline <= block.timestamp) revert harvestingExpired();
-    if (!isSignedByValidator(0, hashHarvesting(_msgSender(), amount, deadline, randomNonce, opId), signature0))
+    if (!isSignedByAValidator(0, 2, hashHarvesting(_msgSender(), amount, deadline, randomNonce, opId), signature0))
       revert invalidPrimarySignature();
-    if (!isSignedByValidator(1, hashHarvesting(_msgSender(), amount, deadline, randomNonce, opId), signature1))
+    if (!isSignedByAValidator(1, 3, hashHarvesting(_msgSender(), amount, deadline, randomNonce, opId), signature1))
       revert invalidSecondarySignature();
     _saveSignatureAsUsed(signature0);
     _saveSignatureAsUsed(signature1);
@@ -469,9 +469,9 @@ contract GamePool is IGamePool, SignableStakes, Constants, UUPSUpgradableTemplat
     bytes calldata signature0,
     bytes calldata signature1
   ) external override {
-    if (!isSignedByValidator(0, hashTurfAttributes(tokenId, attributes, randomNonce), signature0))
+    if (!isSignedByAValidator(0, 2, hashTurfAttributes(tokenId, attributes, randomNonce), signature0))
       revert invalidPrimarySignature();
-    if (!isSignedByValidator(1, hashTurfAttributes(tokenId, attributes, randomNonce), signature1))
+    if (!isSignedByAValidator(1, 3, hashTurfAttributes(tokenId, attributes, randomNonce), signature1))
       revert invalidSecondarySignature();
     _saveSignatureAsUsed(signature0);
     _saveSignatureAsUsed(signature1);
@@ -513,9 +513,9 @@ contract GamePool is IGamePool, SignableStakes, Constants, UUPSUpgradableTemplat
     bytes calldata signature0,
     bytes calldata signature1
   ) external {
-    if (!isSignedByValidator(0, hashFarmAttributes(tokenId, attributes, randomNonce), signature0))
+    if (!isSignedByAValidator(0, 2, hashFarmAttributes(tokenId, attributes, randomNonce), signature0))
       revert invalidPrimarySignature();
-    if (!isSignedByValidator(1, hashFarmAttributes(tokenId, attributes, randomNonce), signature1))
+    if (!isSignedByAValidator(1, 3, hashFarmAttributes(tokenId, attributes, randomNonce), signature1))
       revert invalidSecondarySignature();
     _saveSignatureAsUsed(signature0);
     _saveSignatureAsUsed(signature1);

--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -66,6 +66,7 @@ abstract contract SuperpowerNFTBase is
   error LockerNotApproved();
   error ZeroAddress();
   error NotAnAttributablePlayer();
+  error NotTheAssetOwner();
 
   string private _baseTokenURI;
   bool private _baseTokenURIFrozen;

--- a/contracts/utils/Signable.sol
+++ b/contracts/utils/Signable.sol
@@ -14,7 +14,7 @@ contract Signable is Initializable, OwnableUpgradeable {
 
   event ValidatorSet(uint256 id, address validator);
 
-  mapping(uint256 => address) public validators;
+  mapping(uint256 => address) private _validators;
 
   // solhint-disable-next-line
   function __Signable_init() internal initializer {
@@ -23,8 +23,21 @@ contract Signable is Initializable, OwnableUpgradeable {
 
   function setValidator(uint256 id, address validator) external onlyOwner {
     require(validator != address(0), "Signable: address zero not allowed");
-    validators[id] = validator;
+    _validators[id] = validator;
     emit ValidatorSet(id, validator);
+  }
+
+  function getValidator(uint256 id) external view returns (address) {
+    return _validators[id];
+  }
+
+  function isValidator(address validator, uint256 maxId) external view returns (bool) {
+    for (uint256 i = 0; i <= maxId; i++) {
+      if (_validators[i] == validator) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** @dev how to use it:
@@ -40,6 +53,15 @@ contract Signable is Initializable, OwnableUpgradeable {
     bytes32 hash,
     bytes memory signature
   ) public view returns (bool) {
-    return validators[id] != address(0) && validators[id] == hash.recover(signature);
+    return _validators[id] != address(0) && _validators[id] == hash.recover(signature);
+  }
+
+  function isSignedByAValidator(
+    uint256 id0,
+    uint256 id1,
+    bytes32 hash,
+    bytes memory signature
+  ) public view returns (bool) {
+    return isSignedByValidator(id0, hash, signature) || isSignedByValidator(id1, hash, signature);
   }
 }


### PR DESCRIPTION
If we want to rotate the validators, we need a way to use alternate validators during the transition.
Here we modify Signable adding a function that checks it the signer is one in two validators. 
Normally, there would be only a single validator, but during the transitions, a second validator is set to avoid breaking the process.