### PR TITLE
Fix findings in GamePool

### DIFF
--- a/contracts/SuperpowerNFTBase.sol
+++ b/contracts/SuperpowerNFTBase.sol
@@ -50,6 +50,8 @@ abstract contract SuperpowerNFTBase is
 {
   using AddressUpgradeable for address;
 
+  event AttributesUpdated(uint256 _id, uint256 _index, uint256 _attributes);
+
   error NotALocker();
   error NotTheGame();
   error NotTheAssetOwnerNorTheGame();
@@ -162,6 +164,7 @@ abstract contract SuperpowerNFTBase is
     // notice that if the playes set the attributes to zero, it de-authorize itself
     // and not more changes will be allowed until the NFT owner authorize it again
     _tokenAttributes[_id][_msgSender()][_index] = _attributes;
+    emit AttributesUpdated(_id, _index, _attributes);
   }
 
   function supportsInterface(bytes4 interfaceId)


### PR DESCRIPTION
- Remove the unused error `onlyOnTestnet`

- Adds events 
```
  event AssetStaked(address from, uint8 tokenType, uint16 tokenId);
  event AssetUnstaked(address to, uint8 tokenType, uint16 tokenId);
  event WithdrawnFT(uint8 tokenType, uint256 amount, address beneficiary);
```
in GamePool, and 
```
event AttributesUpdated(uint256 _id, uint256 _index, uint256 _attributes);
```
in SuperpowerNFTBase

- Adds a comment to explain why an unused mapping cannot be removed without making the contract no more upgradeable